### PR TITLE
Generate products file

### DIFF
--- a/mmv1/provider/tflint.rb
+++ b/mmv1/provider/tflint.rb
@@ -2,11 +2,14 @@ require 'provider/abstract_core'
 
 module Provider
   class TFLint < Provider::Terraform
-    def generate_resource(pwd, data, generate_code, generate_docs)
-      @rule_names = []
+    @@rule_names = []
+    @@api_products = {}
 
+    def generate_resource(pwd, data, generate_code, generate_docs)
       tf_product = (@config.legacy_name || data.product.name).underscore
       @terraform_name = data.object.legacy_name || "google_#{tf_product}_#{data.object.name.underscore}"
+
+      @@api_products[@terraform_name] = data.product
 
       data.object.all_user_properties.each do |prop|
         next if prop.output
@@ -17,15 +20,7 @@ module Provider
 
         data.generate(pwd, '/templates/tflint/rule.go.erb', "#{@rule_name}.go", self)
 
-        @rule_names << @rule_name
-      end
-
-      return if @rule_names.empty?
-      # FIXME: Keep rule names independent of external files
-      File.open('/tmp/rulenames.txt', 'a') do |f|
-        @rule_names.each do |name|
-          f.puts "#{name}\n"
-        end
+        @@rule_names << @rule_name
       end
     end
 
@@ -38,9 +33,8 @@ module Provider
     def generate_operation(pwd, output_folder, _types) end
 
     def compile_common_files(output_folder, products, common_compile_file)
-      # FIXME: Keep rule names independent of external files
-      @rule_names = File.read('/tmp/rulenames.txt').split("\n").sort
-      File.delete('/tmp/rulenames.txt')
+      @rule_names = @@rule_names.sort
+      @api_products = @@api_products
 
       Google::LOGGER.info 'Compiling common files.'
       file_template = ProviderFileTemplate.new(
@@ -50,6 +44,7 @@ module Provider
         products
       )
       compile_file_list(output_folder, [['provider.go', 'templates/tflint/provider.go.erb']], file_template)
+      compile_file_list(output_folder, [['product.go', 'templates/tflint/product.go.erb']], file_template)
     end
 
     def copy_common_files(output_folder, generate_code, generate_docs)

--- a/mmv1/templates/tflint/product.go.erb
+++ b/mmv1/templates/tflint/product.go.erb
@@ -1,0 +1,27 @@
+<%= lines(autogen_notice(:go, pwd)) -%>
+
+package magicmodules
+
+// Product is a Go representation of Api::Product
+type Product struct {
+	APIsRequired []APIReference
+}
+
+// APIRequired is a Go reprensentation of Api::Product::ApiReference
+type APIReference struct {
+	Name string
+	URL  string
+}
+
+// Products is a list of Google API products defined in `magic-modules/products/*/api.yaml`
+var Products = map[string]Product{
+	<% @api_products.each do |name, product| -%>
+	"<%= name -%>": {
+		APIsRequired: []APIReference{
+		<% (product.apis_required || []).each do |ref| -%>
+			{ Name: "<%= ref.name %>", URL: "<%= ref.url %>" },
+		<% end -%>
+		},
+	},
+	<% end -%>
+}


### PR DESCRIPTION
Generate the products file so that you can freely refer to the API definition of `magic-modules/products/*/api.yaml` from Go.