### PR TITLE
Follow up of upstream Magic Modules changes

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -148,7 +148,7 @@ all_product_files = all_product_files.sort_by { |product| product == 'products/c
 # products_for_version entries are a hash of product definitions (:definitions)
 # and provider config (:overrides) for the product
 # rubocop:disable Metrics/BlockLength
-products_for_version = Parallel.map(all_product_files, in_processes: 8) do |product_name|
+products_for_version = all_product_files.map do |product_name|
   product_override_path = ''
   product_override_path = File.join(override_dir, product_name, 'product.yaml') if override_dir
   product_yaml_path = File.join(product_name, 'product.yaml')

--- a/mmv1/provider/tflint.rb
+++ b/mmv1/provider/tflint.rb
@@ -50,8 +50,6 @@ module Provider
     def copy_common_files(output_folder, generate_code, generate_docs)
       Google::LOGGER.info 'Copying common files.'
       copy_file_list(output_folder, [
-                       ['validation.go',
-                        'third_party/terraform/utils/validation.go'],
                        ['verify/validation.go',
                         'third_party/terraform/verify/validation.go'],
                     ])


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/magic-modules/pull/8720
See https://github.com/GoogleCloudPlatform/magic-modules/pull/8381

`third_party/terraform/utils/validation.go` is now removed in https://github.com/GoogleCloudPlatform/magic-modules/pull/8720. This is no longer in used. Follow this change and remove the copy this file in the TFLint provider.

This PR also disables the parallelization introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/8381. Since the TFLint provider uses class variables to pass the list of rule names to the final step, parallelization cannot be used.