### PR TITLE
Sync fork with GitHub App token

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -4,13 +4,15 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch: # Enables on-demand/manual triggering
 
-permissions:
-  contents: write
-
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - run: gh repo sync ${{github.repository}}
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
See https://github.com/terraform-linters/magic-modules/actions/runs/13745172118/job/38439197950
See https://github.com/cli/cli/issues/7574

The auto-sync introduced in https://github.com/terraform-linters/magic-modules/pull/7 failed with the following error:

```
HTTP 404: Not Found (https://api.github.com/repos/GoogleCloudPlatform/magic-modules/git/refs/heads/tflint_provider)
```

The cause of this confusing error is that the `GITHUB_TOKEN` issued by GitHub Actions does not have the permissions to modify workflow files. See https://github.com/cli/cli/issues/7574

This is a security feature, and to work around it you need to issue a temporary token using something like [actions/create-github-app-token](https://github.com/actions/create-github-app-token).

In this PR, we will use the [tflint-automation app](https://github.com/apps/tflint-automation) created in this organization to issue a token and use it for `gh repo sync`.